### PR TITLE
Fix image path for tokens

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -78,7 +78,7 @@ function Token({ name = 'default', onClick, isShadowAnimated = false, playing })
   return (
     <TokenStyled color={color} onClick={handleClick} name={name} isShadowAnimated={isShadowAnimated} playing={playing}>
       <div className="box">
-        <img src={`./images/icon-${name}.svg`} alt="" />
+        <img src={`/rock-paper-scissors-react/images/icon-${name}.svg`} alt="" />
       </div>
     </TokenStyled>
   )


### PR DESCRIPTION
The images were not displayed correctly for the tokens:

![tokens](https://user-images.githubusercontent.com/10945334/91623365-817ee080-e99b-11ea-8166-321ee2d2b6e9.png)
